### PR TITLE
Add network nemeses

### DIFF
--- a/src/jepsen/rqlite.clj
+++ b/src/jepsen/rqlite.clj
@@ -16,13 +16,15 @@
     :default  100
     :parse-fn #(Long/parseLong %)
     :validate [pos? "Must be a positive integer."]]
-   [nil "--nemesis-type partition|hammer" "Nemesis used."
+   [nil "--nemesis-type partition|hammer|flaky|slow" "Nemesis used."
     :default :partition
     :parse-fn #(case %
                  ("partition") :partition
                  ("hammer") :hammer
+                 ("flaky") :flaky
+                 ("slow") :slow
                  :invalid)
-    :validate [#{:partition :hammer} "Unsupported nemesis"]]])
+    :validate [#{:partition :hammer :flaky :slow} "Unsupported nemesis"]]])
 
 (defn -main
   "Handles command line arguments. Can either run a test, or a web server for

--- a/src/jepsen/rqlite/nemesis.clj
+++ b/src/jepsen/rqlite/nemesis.clj
@@ -1,0 +1,73 @@
+(ns jepsen.rqlite.nemesis
+  "Custom nemeses for testing rqlited"
+  (:refer-clojure :exclude [test])
+  (:require [clojure.tools.logging :refer :all]
+            [jepsen
+             [net :as net]
+             [control :as c]
+             [nemesis :as nemesis]]))
+
+(defn heal
+  "Heals the network, removing any slowdown or flaky delivery"
+  [net test]
+  (c/with-test-nodes test
+    (try
+      (c/su (c/exec "/sbin/tc" :qdisc :del :dev :eth1 :root))
+      (catch RuntimeException e
+        (if (re-find #"Cannot delete qdisc with handle of zero"
+                     (.getMessage e))
+          nil
+          (throw e))))))
+
+(defn set-delay [net test {:keys [mean variance distribution]
+                           :or   {mean         50
+                                  variance     10
+                                  distribution :normal}}]
+  (c/with-test-nodes test
+    (c/su (c/exec "/sbin/tc" :qdisc :add :dev :eth1 :root :netem :delay
+                  (str mean "ms")
+                  (str variance "ms")
+                  :distribution distribution))))
+
+(defn slow
+  "Slows the network by dt s on start. 
+   Restores network speeds on stop."
+  [dt]
+  (reify nemesis/Nemesis
+    (setup! [this test]
+      (heal (:net test) test)
+      this)
+
+    (invoke! [this test op]
+      (case (:f op)
+        :start (do (set-delay (:net test) test {:mean (* dt 1000) :variance 1})
+                   (assoc op :type :info :value :started))
+
+        :stop (do (heal (:net test) test)
+                  (assoc op :type :info :value :stopped))))
+
+    (teardown! [this test]
+      (heal (:net test) test))))
+
+(defn flaky
+  "Introduces randomized packet loss on start. 
+   Restores network integrity on stop."
+  []
+  (reify nemesis/Nemesis
+    (setup! [this test]
+      (heal (:net test) test)
+      this)
+
+    (invoke! [this test op]
+      (case (:f op)
+        :start (do
+                 (c/with-test-nodes test
+                   (c/su (c/exec "/sbin/tc" :qdisc :replace :dev :eth1 :root :netem :loss "20%"
+                                 "75%")))
+                 (assoc op :type :info :value :started))
+
+        :stop (do (heal (:net test) test)
+                  (assoc op :type :info :value :stopped))))
+
+    (teardown! [this test]
+      (heal (:net test) test))))

--- a/src/jepsen/rqlite/register.clj
+++ b/src/jepsen/rqlite/register.clj
@@ -9,6 +9,7 @@
              [independent :as independent]
              [nemesis :as nemesis]]
             [jepsen.rqlite.common :as rqlite]
+            [jepsen.rqlite.nemesis :as nem]
             [jepsen.checker.timeline :as timeline]
             [knossos.model :as model])
   (:import com.rqlite.Rqlite)
@@ -107,7 +108,9 @@
           :client (Client. (atom false) nil)
           :nemesis (case (:nemesis-type opts)
                      :partition (nemesis/partition-random-halves)
-                     :hammer (nemesis/hammer-time "rqlited"))
+                     :hammer (nemesis/hammer-time "rqlited")
+                     :flaky (nem/flaky)
+                     :slow (nem/slow 1.0))
           :checker (checker/compose
                     {:perf   (checker/perf)
                      :indep (independent/checker


### PR DESCRIPTION
Two nemeses added:
- Flaky: Randomly drops 20% of packets on the network.
- Slow: Delays packets by ~1s (normally distributed with variance 1).

Can be configured on the command line using flag `--nemesis-type`.

Example use: `./run.sh --skip-vagrant --nemesis-type slow`.

Only applies to `register` test now, but is easy to extend to other tests.